### PR TITLE
[#20] Add dynamic templates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,6 +118,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixedbitset"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,6 +259,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "ordermap"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a86ed3f5f244b372d6b1a00b72ef7f8876d0bc6a78a4c9985c53614041512063"
+
+[[package]]
 name = "os_str_bytes"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -263,6 +275,16 @@ name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "petgraph"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3659d1ee90221741f65dd128d9998311b0e40c5d3c23a62445938214abce4f"
+dependencies = [
+ "fixedbitset",
+ "ordermap",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -561,6 +583,7 @@ dependencies = [
  "clap",
  "ipnetwork",
  "log",
+ "petgraph",
  "pretty_env_logger",
  "qrcode",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,5 @@ qrcode = { version = "0.12", default-features = false }
 ipnetwork = "0.19.0"
 clap = "3.1.16"
 pretty_env_logger = "0.4"
+
+petgraph = "0.4.7"

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -565,6 +565,9 @@ impl WireguardNetworkInfo {
         }) {
             let a = peer_indices[&peer];
             let b = peer_indices[&template];
+            // let b = peer_indices
+            //     .get(template)
+            //     .ok_or(format!("No peer with name '{}' found", template))?;
             graph.add_edge(a, b, ());
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,11 +77,7 @@ fn command_init_config(matches: &clap::ArgMatches) -> configs::WireguardNetworkI
     }
 }
 
-fn parse_peer_edit_command(
-    cfg: &WireguardNetworkInfo,
-    peer: &mut configs::PeerInfo,
-    matches: &clap::ArgMatches,
-) -> RVoid {
+fn parse_peer_edit_command(peer: &mut configs::PeerInfo, matches: &clap::ArgMatches) -> RVoid {
     if let Some(endpoint) = matches.value_of("endpoint") {
         peer.endpoint = Some(check_endpoint(endpoint.to_string())?);
     }
@@ -112,19 +108,12 @@ fn parse_peer_edit_command(
     }
 
     if let Some(template_name) = matches.value_of("use-template") {
-        if let Some(_) = cfg.by_name(template_name) {
-            peer.flags.insert(
-                0,
-                configs::PeerFlag::UseTemplate {
-                    peer: template_name.to_string(),
-                },
-            );
-        } else {
-            Err(format!(
-                "Peer you are trying to use as a template ({}) doesn't exist!",
-                template_name
-            ))?
-        }
+        peer.flags.insert(
+            0,
+            configs::PeerFlag::UseTemplate {
+                peer: template_name.to_string(),
+            },
+        );
     }
 
     if matches.is_present("center") {
@@ -174,7 +163,7 @@ fn command_new_peer(cfg: &mut configs::WireguardNetworkInfo, matches: &clap::Arg
         ips: vec![],
     };
 
-    parse_peer_edit_command(cfg, &mut peer, matches)?;
+    parse_peer_edit_command(&mut peer, matches)?;
 
     for net in &cfg.networks {
         peer.ips.push(cfg.get_free_net_address(*net)?);
@@ -212,12 +201,9 @@ fn command_list_peers(cfg: &configs::WireguardNetworkInfo, _: &clap::ArgMatches)
 
 fn command_edit_peer(cfg: &mut configs::WireguardNetworkInfo, matches: &clap::ArgMatches) -> RVoid {
     let name: String = matches.value_of("name").unwrap().into();
-
-    let cfg_copy = cfg.clone();
     let peer = cfg.by_name_mut(&name).ok_or("No peer with this name.")?;
 
-    parse_peer_edit_command(&cfg_copy, peer, matches)?;
-
+    parse_peer_edit_command(peer, matches)?;
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,9 +112,13 @@ fn parse_peer_edit_command(
     }
 
     if let Some(template_name) = matches.value_of("use-template") {
-        if let Some(template) = cfg.by_name(template_name) {
-            peer.flags
-                .insert(0, configs::PeerFlag::UseTemplate { peer: template.id });
+        if let Some(_) = cfg.by_name(template_name) {
+            peer.flags.insert(
+                0,
+                configs::PeerFlag::UseTemplate {
+                    peer: template_name.to_string(),
+                },
+            );
         } else {
             Err(format!(
                 "Peer you are trying to use as a template ({}) doesn't exist!",
@@ -510,7 +514,7 @@ fn main() {
             .peers
             .iter()
             .position(|f| f.name == name)
-            .ok_or("".to_string())?;
+            .ok_or(format!("No peer with name '{}' found", name))?;
         cfg.peers.remove(peer);
         Ok(())
     }

--- a/wg-bond.json
+++ b/wg-bond.json
@@ -6,43 +6,58 @@
   ],
   "peers": [
     {
-      "name": "1",
-      "private_key": "2KT/BLCWqWWONoRuQzlTY+H/mbPPfZ5vAG+cp95duEk=",
+      "name": "DNS",
+      "private_key": "QCTfTeZ9QaopEpOQJKCVnDhBs36Pn55YOHP1fbvav1E=",
       "id": 1,
       "flags": [
         {
           "DNS": {
             "addresses": [
-              "8.8.8.4"
+              "9.9.9.9"
             ]
-          }
-        },
-        {
-          "Gateway": {
-            "ignore_local_networks": true
-          }
-        },
-        {
-          "Keepalive": {
-            "keepalive": 30
           }
         }
       ],
-      "endpoint": "hello.world:8080",
+      "endpoint": null,
       "ips": [
         "10.0.0.1"
       ]
     },
     {
-      "name": "2",
-      "private_key": "cGtVWUqdjDdkzS7tpcaRwSyN4yKX2j7jRK9uH2WncWg=",
+      "name": "PHONE",
+      "private_key": "EP/BMVprMIDtSovubFmXbHBHPZk2hvqpsgpXhehaM0k=",
       "id": 2,
       "flags": [
-        "Template"
+        {
+          "Keepalive": {
+            "keepalive": 30
+          }
+        },
+        {
+          "UseTemplate": {
+            "peer": 1
+          }
+        }
       ],
-      "endpoint": null,
+      "endpoint": "s.4:9009",
       "ips": [
         "10.0.0.2"
+      ]
+    },
+    {
+      "name": "sasha",
+      "private_key": "WFIg/4EwwmNauSQ/kJa73/v/rVsaiiF7kSmzexrAHmg=",
+      "id": 3,
+      "flags": [
+        {
+          "UseTemplate": {
+            "peer": 2
+          }
+        }
+      ],
+      "endpoint": "sasha.ru:9090",
+      "ips": [
+        "10.0.0.3"
       ]
     }
   ],

--- a/wg-bond.json
+++ b/wg-bond.json
@@ -6,58 +6,19 @@
   ],
   "peers": [
     {
-      "name": "DNS",
-      "private_key": "QCTfTeZ9QaopEpOQJKCVnDhBs36Pn55YOHP1fbvav1E=",
+      "name": "1",
+      "private_key": "8ET1CLSUkkU8Fwdm+7fxdrQKgHemGBxqn7hNg5oRE1Y=",
       "id": 1,
       "flags": [
         {
-          "DNS": {
-            "addresses": [
-              "9.9.9.9"
-            ]
+          "UseTemplate": {
+            "peer": "2"
           }
         }
       ],
       "endpoint": null,
       "ips": [
         "10.0.0.1"
-      ]
-    },
-    {
-      "name": "PHONE",
-      "private_key": "EP/BMVprMIDtSovubFmXbHBHPZk2hvqpsgpXhehaM0k=",
-      "id": 2,
-      "flags": [
-        {
-          "Keepalive": {
-            "keepalive": 30
-          }
-        },
-        {
-          "UseTemplate": {
-            "peer": 1
-          }
-        }
-      ],
-      "endpoint": "s.4:9009",
-      "ips": [
-        "10.0.0.2"
-      ]
-    },
-    {
-      "name": "sasha",
-      "private_key": "WFIg/4EwwmNauSQ/kJa73/v/rVsaiiF7kSmzexrAHmg=",
-      "id": 3,
-      "flags": [
-        {
-          "UseTemplate": {
-            "peer": 2
-          }
-        }
-      ],
-      "endpoint": "sasha.ru:9090",
-      "ips": [
-        "10.0.0.3"
       ]
     }
   ],


### PR DESCRIPTION
## Description

Problem: no options for bulk-editing peer configurations.

Solution: dynamic templates. Use petgraph library for processing
template dependencies graph.

## Related Issues
Fixes #20 